### PR TITLE
버그 수정

### DIFF
--- a/main.html
+++ b/main.html
@@ -23,7 +23,7 @@
         <div class="sort-options">
             <label for="sortSelect"></label>
             <select id="sortSelect">
-                <option value="rating">인기순</option>
+                <option value="rating">평점순</option>
                 <option value="views">조회수순</option>
                 <option value="release_date">개봉일순</option>
             </select>

--- a/scripts.js
+++ b/scripts.js
@@ -112,7 +112,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (document.getElementById('profileForm')) {
         const userPreferences = JSON.parse(localStorage.getItem('userPreferences')) || [];
         userPreferences.forEach(preference => {
-            document.getElementById(preference.toLowerCase())?.setAttribute('checked', true);
+            const checkbox = document.getElementById(preference);
+            if (checkbox) {
+                checkbox.checked = true;
+            }
         });
 
         document.getElementById('cancelButton').addEventListener('click', () => {


### PR DESCRIPTION
마이페이지에서 SF를 선택해서 저장한 뒤 메인페이지로 갔다가, 다시 마이페이지로 돌아오면 SF선택이 풀려있는 버그가 발견됐습니다.
이는 scripts.js 코드 중 /* 프로필 페이지에 유저 데이터 로드 */ 부분에서 
preference 값을 소문자로 변환하여
document.getElementById(preference.toLowerCase())로 선택하고 있었기 때문인것으로 보였습니다. 
개발 초기에 preference 값을 영어 데이터로 받아올 때 소문자로 변환하는 것이 필요했는데, 이젠 대부분 한국어 데이터로 받아오기에 더이상 필요없는 방식이 됐습니다.
그러므로 preference 값이 대문자로 저장되는 경우를 처리하기 위해 
document.getElementById(preference)로 변경했습니다.